### PR TITLE
Feature/Filtering | Filter Page 구현

### DIFF
--- a/src/components/RestaurantList/index.tsx
+++ b/src/components/RestaurantList/index.tsx
@@ -1,0 +1,120 @@
+import { useState } from 'react';
+import { Box, Checkbox, List, ListItem, Icon } from '@mui/material';
+import MenuBookIcon from '@mui/icons-material/MenuBook';
+
+import { Restaurant } from '../../models/restaurant';
+
+interface RestaurantsProps {
+  restaurants: Restaurant[];
+}
+
+export default function RestaurantList({ restaurants }: RestaurantsProps) {
+  const [selectedRestaurants, setSelectedRestaurants] = useState<boolean[]>(new Array(restaurants.length).fill(false));
+
+  const handleToggle = (index: number) => {
+    const updatedSelection = [...selectedRestaurants];
+    updatedSelection[index] = !updatedSelection[index];
+
+    setSelectedRestaurants(updatedSelection);
+  };
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '70vh',
+      }}
+    >
+      <List
+        dense
+        sx={{
+          width: '60%',
+          maxWidth: '100%',
+          maxHeight: '80vh',
+          bgcolor: 'background.paper',
+          overflowY: 'scroll',
+        }}
+      >
+        {restaurants.map((restaurant) => (
+          <ListItem
+            key={restaurant.id}
+            sx={{
+              display: 'flex',
+              flexDirection: { xs: 'column', md: 'row' },
+              alignItems: 'center',
+              bgcolor: 'background.paper',
+              overflow: 'hidden',
+              borderRadius: '12px',
+              boxShadow: 1,
+              fontWeight: 'bold',
+              width: '100%',
+              marginTop: 2,
+            }}
+            disablePadding
+          >
+            <Checkbox
+              checked={selectedRestaurants[restaurant.id] || false}
+              onChange={() => handleToggle(restaurant.id)}
+            />
+
+            <Box
+              component="img"
+              sx={{
+                height: 267,
+                width: 350,
+                maxHeight: { xs: 267, md: 243 },
+                maxWidth: { xs: 350, md: 250 },
+              }}
+              alt={`Restaurant near you - ${restaurant.restaurantName}`}
+              src={restaurant.img_dir}
+            />
+
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 2,
+                alignItems: { xs: 'center', md: 'flex-start' },
+                m: 3,
+                minWidth: { md: 350 },
+              }}
+            >
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  gap: 2,
+                  alignItems: { xs: 'center', md: 'flex-start' },
+                  minWidth: { md: 350 },
+                }}
+              >
+                <Box component="span" sx={{ fontSize: 14, mt: 1, bgcolor: '#90EE90', p: 0.7, borderRadius: '8px' }}>
+                  {restaurant.location.locationName}
+                </Box>
+
+                {restaurant.categories.map((category, index) => (
+                  <Box component="span" sx={{ fontSize: 14, mt: 1, bgcolor: '#B0E0E6', p: 0.7, borderRadius: '8px' }}>
+                    <span key={index}>{category.categoryName}</span>
+                  </Box>
+                ))}
+              </Box>
+
+              <Box component="span" sx={{ fontSize: 25 }}>
+                {restaurant.restaurantName}
+              </Box>
+              <Icon>
+                <MenuBookIcon />
+              </Icon>
+            </Box>
+            <Box component="span" sx={{ fontSize: 15 }}>
+              {restaurant.description}
+            </Box>
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  );
+}

--- a/src/models/restaurant.ts
+++ b/src/models/restaurant.ts
@@ -1,0 +1,18 @@
+interface Location {
+  id: number;
+  locationName: string;
+}
+
+interface Category {
+  id: number;
+  categoryName: string;
+}
+
+export interface Restaurant {
+  id: number;
+  restaurantName: string;
+  location: Location;
+  categories: Category[];
+  img_dir: string;
+  description: string;
+}

--- a/src/pages/Filter/index.tsx
+++ b/src/pages/Filter/index.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Theme, useTheme } from '@mui/material/styles';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
+import { Button, Box, Chip, FormControl, Input, InputLabel, MenuItem, OutlinedInput } from '@mui/material';
+
+import Restaurants from '../../components/RestaurantList';
+
+const ITEM_HEIGHT = 48;
+const ITEM_PADDING_TOP = 8;
+const MenuProps = {
+  PaperProps: {
+    style: {
+      maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
+      width: 250,
+    },
+  },
+};
+
+function getStyles(name: string, filterName: readonly string[], theme: Theme) {
+  return {
+    fontWeight:
+      filterName.indexOf(name) === -1 ? theme.typography.fontWeightRegular : theme.typography.fontWeightMedium,
+  };
+}
+
+export function FilterPage() {
+  const [locationsAndCategories, setLocationsAndCategories] = useState({
+    locations: [],
+    categories: [],
+  });
+  const [checkedLocations, setCheckedLocations] = useState<string[]>([]);
+  const [checkedCategories, setCheckedCategories] = useState<string[]>([]);
+  const [restaurants, setRestaurants] = useState([]);
+
+  async function getLocationsAndCategories() {
+    try {
+      const { data: response, status } = await axios.get(`${process.env.REACT_APP_API_URL}/poll`);
+      if (status === 200) {
+        setLocationsAndCategories(response);
+      } else {
+        throw new Error();
+      }
+    } catch (error) {
+      console.error('위치, 카테고리 정보를 가져오는데 실패했습니다.');
+    }
+  }
+
+  async function getRestaurants() {
+    try {
+      const selectedLocationsQuery = checkedLocations.join(',');
+      const selectedCategoriesQuery = checkedCategories.join(',');
+
+      const { data: response, status } = await axios.get(`${process.env.REACT_APP_API_URL}/poll/restaurant`, {
+        params: {
+          locations: selectedLocationsQuery,
+          categories: selectedCategoriesQuery,
+        },
+      });
+
+      if (status === 200) {
+        setRestaurants(response);
+      } else {
+        throw new Error();
+      }
+    } catch {
+      console.error('식당 정보를 가져오는데 실패했습니다.');
+    }
+  }
+
+  useEffect(() => {
+    getLocationsAndCategories(); // 렌더링 후 한번만 실행
+  }, []);
+
+  useEffect(() => {
+    getRestaurants();
+  }, [checkedLocations, checkedCategories]); // locations, categories가 변할 때 마다 실행
+
+  const theme = useTheme();
+
+  const handleChangeLocation = (event: SelectChangeEvent<typeof checkedLocations>) => {
+    const {
+      target: { value },
+    } = event;
+    setCheckedLocations(typeof value === 'string' ? value.split(',') : value);
+  };
+  const handleChangeCategory = (event: SelectChangeEvent<typeof checkedCategories>) => {
+    const {
+      target: { value },
+    } = event;
+    setCheckedCategories(typeof value === 'string' ? value.split(',') : value);
+  };
+
+  return (
+    <div>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '10px',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Box sx={{ marginTop: '3%', width: '60%' }}>
+          <Input placeholder="투표방 이름을 설정하세요. " size="medium" />
+          <Button sx={{ marginleft: '3%' }}>설정</Button>
+        </Box>
+        <FormControl sx={{ m: 1, width: '60%' }}>
+          <InputLabel id="demo-multiple-chip-label">Location</InputLabel>
+          <Select
+            labelId="demo-multiple-chip-label"
+            id="demo-multiple-chip"
+            multiple
+            value={checkedLocations}
+            onChange={handleChangeLocation}
+            input={<OutlinedInput id="select-multiple-chip" label="Chip" />}
+            renderValue={(selected) => (
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                {selected.map((value) => (
+                  <Chip key={value} label={value} />
+                ))}
+              </Box>
+            )}
+            MenuProps={MenuProps}
+          >
+            {locationsAndCategories.locations.map((location, index) => (
+              <MenuItem key={index} value={location} style={getStyles(location, checkedLocations, theme)}>
+                {location}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <FormControl sx={{ m: 1, width: '60%' }}>
+          <InputLabel id="demo-multiple-chip-label">Category</InputLabel>
+          <Select
+            labelId="demo-multiple-chip-label"
+            id="demo-multiple-chip"
+            multiple
+            value={checkedCategories}
+            onChange={handleChangeCategory}
+            input={<OutlinedInput id="select-multiple-chip" label="Chip" />}
+            renderValue={(selected) => (
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                {selected.map((value) => (
+                  <Chip key={value} label={value} />
+                ))}
+              </Box>
+            )}
+            MenuProps={MenuProps}
+          >
+            {locationsAndCategories.categories.map((category, index) => (
+              <MenuItem key={index} value={category} style={getStyles(category, checkedCategories, theme)}>
+                {category}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Box paddingX={3} paddingY={5}>
+          <Restaurants restaurants={restaurants} />
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'right',
+            }}
+          >
+            <Button>투표 시작하기</Button>
+          </Box>
+        </Box>
+      </Box>
+    </div>
+  );
+}

--- a/src/route/index.tsx
+++ b/src/route/index.tsx
@@ -7,6 +7,7 @@ import { ListPage } from '../pages/List';
 import { JoinPage } from '../pages/Join';
 import { InvitePage } from '../pages/Invite';
 import { GuestLoginPage } from '../pages/GuestLogin';
+import { FilterPage } from '../pages/Filter';
 
 /**
  * 어느 url에 어떤 페이지를 보여줄지 정해주는 컴포넌트입니다.
@@ -21,6 +22,7 @@ export function RouteComponent() {
       <Route path="/invite/:url" element={<InvitePage />} />
       <Route path="/login" element={<LoginPage />} />
       <Route path="/join" element={<JoinPage />} />
+      <Route path="/poll" element={<FilterPage />} />
       <Route path="/poll/result/:pollId" element={<ResultPage />} />
     </Routes>
   );


### PR DESCRIPTION
## 컴포넌트
레스토랑 리스트 구현, 투표창 설정 페이지와 투표창 페이지에서 사용할 예정

## Filter Page
- location과 category를 기반으로 필터링된 레스토랑 리스트를 보여주는 페이지 구현
- PM님 말씀대로 네비게이트 없이 state를 이용해서 검색 조건을 바꿀 때 마다 바로 바로 필터링된 리스트가 보이게끔 구현했습니다. 

## 추후 논의사항 / 추가해야 하는 부분
- 이미지가 정상적으로 들어가지 않아 문제 파악이 필요합니다. dir이 제대로 되어있는지 이후에 확인해보겠습니다. 
- 리스트의 디자인을 수정해야 합니다. 현재 아이콘을 넣어뒀는데, 이후에 아이콘을 누르면 메뉴 정보가 보이는 방향으로 수정 계획입니다. 
- 투표 시작하는 창으로 넘어갈 때 axios로 poll 정보, 선택된 레스토랑 리스트 정보를 저장해야합니다. 

기능적으로는 우선 문제 없이 작동합니다. 
혹시 문제가 있다면 말해주세요오