### PR TITLE
feature/sidebar | 사이드바 버튼 연결, 커스텀 버튼 prop 추가, 메인 페이지 소개글 수정

### DIFF
--- a/src/components/CustomButton/index.tsx
+++ b/src/components/CustomButton/index.tsx
@@ -3,11 +3,13 @@ import { Button } from '@mui/material';
 interface CustomButtonProps {
   text: string;
   onClick: (() => Promise<void>) | (() => void);
+  width?: string | number;
+  height?: string | number;
 }
 
-export default function CustomButton({ text, onClick }: CustomButtonProps) {
+export default function CustomButton({ text, onClick, width, height }: CustomButtonProps) {
   return (
-    <Button variant="contained" color="primary" onClick={onClick}>
+    <Button variant="contained" color="primary" onClick={onClick} sx={{ width, height }}>
       {text}
     </Button>
   );

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import * as React from 'react';
 import ListItemText from '@mui/material/ListItemText';
 import ListItemButton from '@mui/material/ListItemButton';
@@ -19,6 +20,10 @@ export default function Sidbar() {
     right: false,
   });
 
+  const navigate = useNavigate();
+
+  const functions = [() => navigate('/history'), () => navigate('/poll'), () => navigate('/donate')];
+
   const toggleDrawer = (anchor: Anchor, open: boolean) => (event: React.KeyboardEvent | React.MouseEvent) => {
     if (
       event.type === 'keydown' &&
@@ -29,6 +34,7 @@ export default function Sidbar() {
 
     setState({ ...state, [anchor]: open });
   };
+
   const list = (anchor: Anchor) => (
     <Box
       sx={{ width: anchor === 'top' || anchor === 'bottom' ? 'auto' : 250 }}
@@ -37,10 +43,13 @@ export default function Sidbar() {
       onKeyDown={toggleDrawer(anchor, false)}
     >
       <List sx={{ mt: 5 }}>
-        {['마이페이지', '투표방 생성하기', '개발자에게 커피사주기'].map((text) => (
+        {['마이페이지', '투표방 생성하기', '개발자에게 커피사주기'].map((text, index) => (
           <ListItem key={text} disablePadding>
             <ListItemButton>
-              <ListItemText primary={<Typography style={{ fontWeight: 800 }}>{text}</Typography>} />
+              <ListItemText
+                primary={<Typography style={{ fontWeight: 800 }}>{text}</Typography>}
+                onClick={functions[index]}
+              />
             </ListItemButton>
           </ListItem>
         ))}

--- a/src/pages/Donate/index.tsx
+++ b/src/pages/Donate/index.tsx
@@ -1,0 +1,10 @@
+import { Box, Typography } from '@mui/material';
+
+export function DonatePage() {
+  return (
+    <Box>
+      <Typography>아래 계좌로 후원</Typography>
+      <Typography>793-910370-23607 하나 문정민</Typography>
+    </Box>
+  );
+}

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -103,9 +103,8 @@ export function MainPage() {
               <Typography marginBottom={1} variant="h3" fontWeight="bold">
                 꾹이란?
               </Typography>
-              <Typography>
-                식당을 고르는 것을 어려워하는 여러분께, 점심 메뉴를 고르다 의 상할 뻔한 당신에게 필요한 서비스 KUUK
-              </Typography>
+              <Typography>꾹은 고려대학교 학생들을 위한 식당 투표 서비스입니다.</Typography>
+              <Typography>꾹을 통해 간편한 투표 생성 및 링크 공유를 통한 참여 기능을 체험하세요.</Typography>
             </Box>
             <Stack spacing={2}>
               <CustomButton text="투표방 생성하기" onClick={() => navigate('/poll')} />

--- a/src/route/index.tsx
+++ b/src/route/index.tsx
@@ -8,6 +8,7 @@ import { JoinPage } from '../pages/Join';
 import { InvitePage } from '../pages/Invite';
 import { GuestLoginPage } from '../pages/GuestLogin';
 import { FilterPage } from '../pages/Filter';
+import { DonatePage } from '../pages/Donate';
 
 /**
  * 어느 url에 어떤 페이지를 보여줄지 정해주는 컴포넌트입니다.
@@ -24,6 +25,7 @@ export function RouteComponent() {
       <Route path="/join" element={<JoinPage />} />
       <Route path="/poll" element={<FilterPage />} />
       <Route path="/poll/result/:pollId" element={<ResultPage />} />
+      <Route path="/donate" element={<DonatePage />} />
     </Routes>
   );
 }


### PR DESCRIPTION
### 변경점
- 사이드바의 3개의 버튼(마이페이지, 투표하러 가기, 개발자에게 후원)을 페이지로 연결했습니다. 
- 이에 따라 개발자 후원 페이지를 새로 추가했습니다(임시본).
- 커스텀 버튼의 높이/너비를 수정할 수 있도록 `prop`을 추가했습니다. 
- 메인 페이지의 서비스 소개글을 수정했습니다. 