### PR TITLE
Feature/reRedesign | Filter 페이지 re디자인 및 기능 수정

### DIFF
--- a/src/components/RestaurantCard/index.tsx
+++ b/src/components/RestaurantCard/index.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react';
+import { styled } from '@mui/material/styles';
+import { IconButtonProps } from '@mui/material/IconButton';
+import {
+  Box,
+  Grid,
+  Card,
+  CardHeader,
+  CardMedia,
+  CardContent,
+  CardActions,
+  Collapse,
+  IconButton,
+  Typography,
+  Checkbox,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+
+import { Restaurant } from '../../models/restaurant';
+
+interface RestaurantsProps {
+  restaurants: Restaurant[];
+  selectedRestaurants: boolean[];
+  setSelectedRestaurants: (newSelectedRestaurants: boolean[]) => void;
+}
+
+interface ExpandMoreProps extends IconButtonProps {
+  expand: boolean;
+}
+
+const ExpandMore = styled((props: ExpandMoreProps) => {
+  const { expand, ...other } = props;
+  return <IconButton {...other} />;
+})(({ theme, expand }) => ({
+  transform: !expand ? 'rotate(0deg)' : 'rotate(180deg)',
+  marginLeft: 'auto',
+  transition: theme.transitions.create('transform', {
+    duration: theme.transitions.duration.shortest,
+  }),
+}));
+
+export default function RestaurantCard({ restaurants, selectedRestaurants, setSelectedRestaurants }: RestaurantsProps) {
+  const [expandedCards, setExpandedCards] = useState<boolean[]>(new Array(restaurants.length).fill(false));
+
+  const handleToggle = (index: number) => {
+    const updatedSelection = [...selectedRestaurants];
+    updatedSelection[index] = !updatedSelection[index];
+
+    setSelectedRestaurants(updatedSelection);
+  };
+
+  const handleExpandClick = (index: number) => {
+    const updatedExpanded = [...expandedCards];
+    updatedExpanded[index] = !updatedExpanded[index];
+
+    setExpandedCards(updatedExpanded);
+  };
+
+  return (
+    <Box>
+      <Grid container spacing={{ xs: 2, md: 3 }} columns={{ xs: 4, sm: 8, md: 12 }} sx={{ justifyContent: 'center' }}>
+        {restaurants.map((restaurant) => (
+          <Card key={restaurant.id} sx={{ maxWidth: 345, width: 300, margin: '1%' }}>
+            <Checkbox
+              checked={selectedRestaurants[restaurant.id] || false}
+              onChange={() => handleToggle(restaurant.id)}
+            />
+            <CardHeader
+              title={restaurant.restaurantName}
+              subheader={
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                    gap: 2,
+                    alignItems: { xs: 'center', md: 'flex-start' },
+                    minWidth: { md: 350 },
+                  }}
+                >
+                  <Box component="span" sx={{ fontSize: 14, mt: 1, bgcolor: '#90EE90', p: 0.7, borderRadius: '8px' }}>
+                    {restaurant.location.locationName}
+                  </Box>
+
+                  {restaurant.categories.map((category, index) => (
+                    <Box component="span" sx={{ fontSize: 14, mt: 1, bgcolor: '#B0E0E6', p: 0.7, borderRadius: '8px' }}>
+                      <span key={index}>{category.categoryName}</span>
+                    </Box>
+                  ))}
+                </Box>
+              }
+            />
+            <CardMedia component="img" height="194" image={restaurant.imgDir} alt={restaurant.restaurantName} />
+            <CardContent>
+              <Typography variant="body2" color="text.secondary">
+                {restaurant.description}
+              </Typography>
+            </CardContent>
+            <CardActions disableSpacing>
+              <ExpandMore
+                expand={expandedCards[restaurant.id]}
+                onClick={() => handleExpandClick(restaurant.id)}
+                aria-expanded={expandedCards[restaurant.id]}
+                aria-label={`show more for ${restaurant.restaurantName}`}
+              >
+                <ExpandMoreIcon />
+              </ExpandMore>
+            </CardActions>
+            <Collapse in={expandedCards[restaurant.id]} timeout="auto" unmountOnExit>
+              <CardContent>
+                <Typography paragraph>Menu:</Typography>
+                {restaurant.menus.map((menu) => (
+                  <Typography paragraph>
+                    {menu.menuName}: {menu.price}원
+                  </Typography>
+                ))}
+              </CardContent>
+            </Collapse>
+          </Card>
+        ))}
+      </Grid>
+    </Box>
+  );
+}

--- a/src/components/RestaurantList/index.tsx
+++ b/src/components/RestaurantList/index.tsx
@@ -69,7 +69,7 @@ export default function RestaurantList({ restaurants }: RestaurantsProps) {
                 maxWidth: { xs: 350, md: 250 },
               }}
               alt={`Restaurant near you - ${restaurant.restaurantName}`}
-              src={restaurant.img_dir}
+              src={restaurant.imgDir}
             />
 
             <Box

--- a/src/models/restaurant.ts
+++ b/src/models/restaurant.ts
@@ -2,10 +2,15 @@ interface Location {
   id: number;
   locationName: string;
 }
-
 interface Category {
   id: number;
   categoryName: string;
+}
+
+interface Menu {
+  id: number;
+  menuName: string;
+  price: string;
 }
 
 export interface Restaurant {
@@ -13,6 +18,7 @@ export interface Restaurant {
   restaurantName: string;
   location: Location;
   categories: Category[];
-  img_dir: string;
+  menus: Menu[];
+  imgDir: string;
   description: string;
 }


### PR DESCRIPTION
### 레스토랑 리스트를 카드 그리드 형태로 변경
### Filter Page와 뒤에 투표창과 연결 구현 완성
### Filter Page 디자인 변경 작업

- 다음 투표 페이지로 넘어가면서 axios post를 통해 레스토랑과 poll 정보 등을 데이터베이스에 저장했습니다. 
- 페이지에서 컴포넌트에 배열을 전달하기 위해 Prop을 선언하여 state와 필터링된 레스토랑 리스트를 Prop 안에 두었습니다. 
- 필터링 페이지의 전반적인 디자인을 수정했습니다. 
- 기존에는 레스토랑 리스트 형식이었지만 가독성을 위해 카드 형식으로 변경하였으며, Fab을 이용해 다음 페이지 넘어가는 버튼을 예쁘게 만들었습니다. 

뒤에 투표 창으로 정상적으로 넘어가는 것을 확인하였으며, 기능상으로는 문제가 없습니다. 
에러가 발생한다면 언제든 알려주세요 🥹 